### PR TITLE
Adding foundation specification topic to call

### DIFF
--- a/telcons/2019-04-11-agenda.md
+++ b/telcons/2019-04-11-agenda.md
@@ -24,4 +24,5 @@
 
 #### Future meetings
 
+* Foundation specification
 * Discuss plans for [2019 TPAC meeting in Fukuoka, Japan](https://www.w3.org/2019/09/TPAC/)


### PR DESCRIPTION
I would like to discuss proposing a foundation specification proposal for folks to review and possibly resolve on in a later telecon to use as the foundation that we evolve for the purposes of this API. Currently when discussing various approaches I think at times folks talk past each other due to mis-understandings and I feel this is rooted in not having spec text that clearly defines both terminology and how these pieces come together to enable the API to handle the use cases we've identified.